### PR TITLE
Modify to work with Portal for ArcGIS

### DIFF
--- a/js/app/controller.js
+++ b/js/app/controller.js
@@ -181,7 +181,7 @@ function(config,
             // if webmap , it will take longer to create - use setInterval to check if map is valid
             var self = this;
             var verifyMap = setInterval(function(){
-                if (self.map == undefined){
+                if (!self.map){
                     console.warn('map not created');
                 } else {
                     clearInterval(verifyMap);
@@ -227,7 +227,7 @@ function(config,
                     }
                     console.debug('map created');                    
             }
-            },1);
+            },100);
             
             
         },
@@ -246,7 +246,7 @@ function(config,
                     } else {                        
                         console.debug('map not complete');
                     }
-                },1);
+                },100);
             }
         },
 

--- a/js/config/config.js
+++ b/js/config/config.js
@@ -17,6 +17,11 @@
 define(function() {
 
     return {
+        /* ----- Portal URL ----- */
+        /* Set portal url for app. Necessary if using webmap with Portal for ArcGIS,
+         * not if using ArcGIS Online. Address should end in "/portal/" */
+        // portalUrl: '//yourserver/portal/',
+
         /*----- Authentication SETTINGS-----*/
         // Authentication is optional. If authentication is needed then, uncomment the 
         // entire authentication object. You'll need to Registar your application with
@@ -24,7 +29,9 @@ define(function() {
         /*authentication: {
             // appId: '',
             // If appId is present and portalUrl is omitted, this authenticates against
-            // *any* arcgisonline account, which is probably not what you want.
+            // *any* arcgisonline account, which is probably not what you want. 
+            // If authenticating against Portal for ArcGIS, the app will use the above
+            // portalUrl if this is not specified. Address should end in "/portal/"
             portalUrl: '//yourportal.maps.arcgis.com',
         }, */
 
@@ -71,7 +78,9 @@ define(function() {
          */
 
         basemapGallery: {
-            portalUrl: 'http://www.arcgis.com',
+            // This can be specified separately from the overall and authentication portal URLs. 
+            // If blank or commented out, this defaults to www.arcgis.com
+            portalUrl: '',
             // 'true' - display the BaseMapGallery button (and therefore the basemaps)
             // 'false' - hide the BaseMapGallery button. The default/only basemap (from list below) is specified in mapSetup.basemap
             showBasemapGallery: true,

--- a/js/main.js
+++ b/js/main.js
@@ -27,9 +27,15 @@ require({
 }, [
     'esri/arcgis/OAuthInfo',
     'esri/IdentityManager',
+    'esri/arcgis/utils',
     'app/controller',
     'config/config', // if you change this, change the one in controller.js too
-    'dojo/domReady!'], function(OAuthInfo, esriID, Controller, config) {
+    'dojo/domReady!'],
+function(OAuthInfo, esriID, arcgisUtils, Controller, config) {
+
+        if (config.portalUrl) {
+            arcgisUtils.arcgisUrl = config.portalUrl + 'sharing/rest/content/items';
+        }
 
         if (config.authentication && config.authentication.appId) {
             var info = new OAuthInfo({
@@ -37,8 +43,11 @@ require({
                 authNamespace: 'portal_oauth_inline',
                 popup: false
             });
-            if (config.portalUrl) {
-                info.portalUrl = config.portalUrl;
+            if (config.authentication.portalUrl || config.portalUrl) {
+                info.portalUrl = config.authentication.portalUrl || config.portalUrl;
+                if (info.portalUrl.indexOf('portal/') === info.portalUrl.length - 7) {
+                    info.portalUrl = info.portalUrl + 'sharing';
+                }
             }
             esriID.registerOAuthInfos([info]);
 


### PR DESCRIPTION
Added another portalUrl to the config file separate from authentication to redirect arcgisUtils to the correct portal when looking for a webmap ID.
